### PR TITLE
chore: add OS matrix and node 22/24 to CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   lint_test:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [22.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [22.x, 24.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Add OS matrix (ubuntu, macos, windows) and Node.js 22/24 to CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)