### PR TITLE
chore: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![npm version](https://badge.fury.io/js/mulmoscript-mcp.svg)](https://badge.fury.io/js/mulmoscript-mcp)
 # mulmoscript for mulmocast generator
 
 ## claude_desktop_config.json


### PR DESCRIPTION
Add npm version badge for `mulmoscript-mcp` package using badge.fury.io